### PR TITLE
Added block code support

### DIFF
--- a/lib/mode.js
+++ b/lib/mode.js
@@ -361,6 +361,13 @@ CodeMirror.defineMode('jade', function (config) {
     }
   }
 
+  function blockCode(stream, state) {
+    if (stream.match(/^-$/)) {
+      setInnerMode(stream, state, 'application/javascript');
+      return 'punctuation';
+    }
+  }
+
   function code(stream, state) {
     if (stream.match(/^(!?=|-)/)) {
       state.javaScriptLine = true;
@@ -584,6 +591,7 @@ CodeMirror.defineMode('jade', function (config) {
       || whileStatement(stream, state)
       || tag(stream, state)
       || filter(stream, state)
+      || blockCode(stream, state)
       || code(stream, state)
       || id(stream, state)
       || className(stream, state)

--- a/test/expected-output/block-code.html
+++ b/test/expected-output/block-code.html
@@ -1,0 +1,12 @@
+<span class="cm-punctuation">-</span>
+<span class="cm-indent">  </span><span class="cm-tag">list</span><span class="cm-string"> = [&quot;uno&quot;, &quot;dos&quot;, &quot;tres&quot;,</span>
+<span class="cm-indent">          </span>&quot;<span class="cm-tag">cuatro</span>&quot;,<span class="cm-string"> &quot;cinco&quot;, &quot;seis&quot;];</span>
+<span class="cm-comment">//- Without a block, the element is accepted and no code is generated</span>
+<span class="cm-punctuation">-</span>
+<span class="cm-keyword">each</span><span class="cm-variable"> item</span><span class="cm-keyword"> in</span> <span class="cm-variable">list</span>
+<span class="cm-indent">  </span><span class="cm-punctuation">-</span>
+<span class="cm-indent">    </span><span class="cm-tag">string</span><span class="cm-string"> = item.charAt(0)</span>
+<span class="cm-indent">    </span>
+<span class="cm-indent">      </span><span class="cm-qualifier">.toUpperCase</span><span class="cm-punctuation">(</span><span class="cm-punctuation">)</span><span class="cm-string"> +</span>
+<span class="cm-indent">    </span><span class="cm-tag">item</span><span class="cm-qualifier">.slice</span><span class="cm-punctuation">(</span><span class="cm-attribute">1</span><span class="cm-punctuation">)</span>;
+<span class="cm-indent">  </span><span class="cm-tag">li</span><span class="cm-punctuation">=</span> <span class="cm-variable">string</span>


### PR DESCRIPTION
Hi @ForbesLindesay ,

Would like to add block code highlighting (mirroring https://github.com/jadejs/jade/pull/1965) - the changes are simple but I also had to change the existing tests' code (namely to replace references to `visionmedia/jade` repository with `jadejs/jade` in `test/index.js` and to mirror the changes made to Jade test cases over time in expected html output files).

I did not incorporate these changes in the pull request (was afraid to break something), but without them the build does not pass the tests. Please let me know what would be the right thing to do.
