### PR TITLE
Add CoffeeScript fragment support

### DIFF
--- a/lib/mode.js
+++ b/lib/mode.js
@@ -479,8 +479,13 @@ CodeMirror.defineMode('jade', function (config) {
   function dot(stream, state) {
     if (stream.eat('.')) {
       var innerMode = null;
-      if (state.lastTag === 'script' && state.scriptType.toLowerCase().indexOf('javascript') != -1) {
-        innerMode = state.scriptType.toLowerCase().replace(/"|'/g, '');
+      if (state.lastTag === 'script') {
+        var strippedType = state.scriptType.toLowerCase().replace(/"|'/g, '');
+        if (state.scriptType.toLowerCase().indexOf('javascript') !== -1) {
+          innerMode = state.scriptType.toLowerCase().replace(/"|'/g, '');
+        } else if (strippedType.indexOf('coffee') === 0 || strippedType.indexOf('text/coffee') === 0) {
+          innerMode = 'coffeescript';
+        }
       } else if (state.lastTag === 'style') {
         innerMode = 'css';
       }


### PR DESCRIPTION
This adds supports for `script(type="coffee")`, `script(type="text/coffee")`, `script(type="coffeescript")`, `script(type="text/coffeescript")`, and so on. The innerMode for these is set to `coffeescript`, so that the default CoffeeScript mode can take care of the syntax highlighting there.

I've tested it in my own Brackets editor, and as far as I can tell, it works fine.

A few notes:

1. I was unable to run tests; I was met with a `NotFound: GET: /repos/visionmedia/jade/contents/test/cases returned Not Found` upon running `npm test`, and no test setup instructions were supplied.
2. The [code that was already there](https://github.com/joepie91/jade-brackets/blob/master/lib/mode.js#L484) for Javascript is broken, and was already broken prior to my change - the inner condition never occurred, and whenever it should have, `state.scriptType` appeared to contain `avascript"` as value. I've not touched this code other than moving it and changing `!=` to `!==`, but this probably needs looking into - right now only an untyped `script` tag works, and `script(type="javascript")`/`script(type="text/javascript")` do not.