### PR TITLE
fix Brackets' deprecation warning in 1.4

### DIFF
--- a/build.js
+++ b/build.js
@@ -34,6 +34,7 @@ var autocomplete = fs.readFileSync(__dirname + '/lib/autocomplete/index.js', 'ut
 var plugin = '';
 plugin += 'define(function (require, exports, module) {\n';
 plugin += '  "use strict";\n\n';
+plugin += '  var CodeMirror = brackets.getModule("thirdparty/CodeMirror/lib/codemirror");\n';
 plugin += '  ' + mode.replace(/\n/gm, '\n  ') + '\n\n';
 plugin += '  var LanguageManager = brackets.getModule("language/LanguageManager");\n';
 plugin += '  LanguageManager.defineLanguage("jade", ' + JSON.stringify(require('./lib/language-definition.js')) + ');\n';


### PR DESCRIPTION
Currently, the deprecation warning is (Brackets 1.4):
```
Use brackets.getModule("thirdparty/CodeMirror/lib/codemirror") instead of global CodeMirror.
    at Object.defineProperty.get (file:///C:/Program%20Files%20(x86)/Brackets/dev/src/brackets.js:113:32)
    at Object.eval (eval at evaluate (unknown source), <anonymous>:1:1)
    at Object.InjectedScript._evaluateOn (<anonymous>:762:103)
    at Object.InjectedScript._evaluateAndWrap (<anonymous>:695:34)
    at Object.InjectedScript.evaluateOnCallFrame (<anonymous>:813:21)
    at Object.deprecationWarning (file:///C:/Program%20Files%20(x86)/Brackets/dev/src/utils/DeprecationWarning.js:90:9)
    at Object.defineProperty.get (file:///C:/Program%20Files%20(x86)/Brackets/dev/src/brackets.js:113:32)
    at Object.<anonymous> (file:///C:/Users/Zaggi/AppData/Roaming/Brackets/extensions/user/jade/main.js:4:3)
    at Object.context.execCb (file:///C:/Program%20Files%20(x86)
```